### PR TITLE
EIP 1193 Improvements

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -7,26 +7,40 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2018-06-30
-requires: 155, 695, 1102, 1474
+requires: 155, 695, 1102, 1474, 1767
 ---
 
 ## Summary
 
-This EIP formalizes an Ethereum Provider JavaScript API for consistency across clients and applications. The provider is designed to be minimal and intended to be available on `window.ethereum` for cross environment compatibility. The events are provided as a convenience to enable reactive dapp UIs.
+This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
+
+The provider is intended to be available on `window.ethereum` so JavaScript dapps can be written once and function in perpetuity.
+
+The provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of any particular transport protocol.
+
+The events `connect`, `close`, `chainChanged`, and `accountsChanged` are provided to enable reactive dapp UIs.
 
 ## API
 
 ### Send
 
-Ethereum JSON-RPC API methods can be sent and received:
+Ethereum API methods can be sent and received through the `send` method.
 
 ```js
-ethereum.send(method: String, params?: Array<any>): Promise<any>;
+ethereum.send(method: String, params?: Array<any> | Object): Promise<any>;
 ```
 
-Promise resolves with `result` or rejects with `Error`.
+If present, `params` for the request can be provided as a structured value, either by-position as an `Array` or by-name as an `Object`.
 
-See [available JSON-RPC methods](https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC#json-rpc-methods).
+Promise resolves with `data` or rejects with `Error`.
+
+#### Transports
+
+Multiple transports may be available.
+
+[EIP 1474](https://eips.ethereum.org/EIPS/eip-1474) specifies the Ethereum JSON-RPC API.
+
+[EIP 1767](https://eips.ethereum.org/EIPS/eip-1767) specifies the Ethereum GraphQL schema.
 
 ### Events
 
@@ -34,15 +48,17 @@ Events are emitted using [EventEmitter](https://nodejs.org/api/events.html).
 
 #### notification
 
-All subscriptions from the node emit on notification. Attach listeners with:
+The provider may emit notifications on the `EventEmitter` key `notification`, such as JSON-RPC notifications and GraphQL subscriptions.
+
+Some clients like [Geth](https://geth.ethereum.org/docs/rpc/pubsub) and [Parity](https://wiki.parity.io/JSONRPC-eth_pubsub-module) support Publish-Subscribe (_Pub-Sub_) using JSON-RPC notifications. This lets you subscribe and wait for events instead of polling for them.
+
+Attach listeners with:
 
 ```js
 ethereum.on('notification', listener: (result: any) => void): this;
 ```
 
-To create a subscription, call `ethereum.send('eth_subscribe', [])` or `ethereum.send('shh_subscribe', [])`.
-
-See the [eth subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) and [shh subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe).
+To create a JSON-RPC subscription, send `ethereum.send('eth_subscribe', yourParams)` or `ethereum.send('shh_subscribe', yourParams)`. See the [eth subscription methods](https://geth.ethereum.org/docs/rpc/pubsub) and [shh subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe).
 
 #### connect
 
@@ -97,9 +113,8 @@ The event emits with `accounts`, an array of the accounts' addresses.
 const ethereum = window.ethereum;
 
 // A) Set provider in web3.js
-var web3 = new Web3(ethereum);
+let web3 = new Web3(ethereum);
 // web3.eth.getBlock('latest', true).then(...)
-
 
 // B) Use provider object directly
 // Example 1: Log last block
@@ -127,7 +142,6 @@ ethereum
     Code: ${error.code}. Data: ${error.data}`
     );
   });
-
 
 // Example 3: Log new blocks
 let subId;
@@ -157,7 +171,6 @@ ethereum
     );
   });
 
-
 // Example 4: Log when accounts change
 const logAccounts = accounts => {
   console.log(`Accounts:\n${accounts.join('\n')}`);
@@ -174,13 +187,27 @@ ethereum.on('close', (code, reason) => {
 
 ## Specification
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### Send
+
+The `send` method **MUST** send a properly formatted request to the underlying client.
+
+If present `params` for the request **MUST** be provided as a structured value, either by-position through an `Array` or by-name through an `Object`.
+
+If the request is successful, the provider **MUST** resolve the promise with the response `result` without any underlying JSON-RPC or GraphQL structure.
+
 ### Errors
 
-If the Ethereum Provider request returns an error property then the Promise **MUST** reject with an `Error` object containing the `error.message` as the Error message, `error.code` as a code property on the error and `error.data` as a data property on the error.
+If the request returns an error then the Promise **MUST** reject with an `Error` object containing the `error.message` as the Error message, `error.code` as a code property on the error and `error.data` as a data property on the error.
 
 If an error occurs during processing, such as an HTTP error or internal parsing error, then the Promise **MUST** reject with an `Error` object.
 
-If the request requires an account that is not yet authenticated, the Promise **MUST** reject with Error code 4100.
+#### Error object and codes
+
+If an `Error` object is returned, it **MUST** contain a human readable string message describing the error and **SHOULD** populate the `code` and `data` properties on the error object with additional error details.
+
+Error codes **SHOULD** follow the table of [error codes listed in EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
 
 ### Events
 
@@ -188,7 +215,7 @@ The provider **SHOULD** extend from `EventEmitter` to provide dapps flexibility 
 
 #### notification
 
-All subscriptions received from the node **MUST** emit the `subscription` property with the subscription ID and a `results` property.
+All subscriptions or notifications received from the client **MUST** emit on the `EventEmitter` key `notification`.
 
 #### connect
 
@@ -206,171 +233,11 @@ If the chain the provider is connected to changes, the provider **MUST** emit an
 
 If the accounts connected to the Ethereum Provider change at any time, the Ethereum Provider **MUST** send an event with the name `accountsChanged` with args `accounts: Array<String>` containing the accounts' addresses.
 
-### Error object and codes
-
-If an Error object is returned, it **MUST** contain a human readable string message describing the error and **SHOULD** populate the `code` and `data` properties on the error object with additional error details.
-
-Appropriate error codes **SHOULD** follow the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes), along with the following table:
-
-| Status code | Name                         | Description                                                              |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------ |
-| 4001        | User Rejected Request        | The user rejected the request.                                           |
-| 4100        | Unauthorized                 | The requested method and/or account has not been authorized by the user. |
-| 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider.    |
-
-## Sample Class Implementation
-
-```js
-class EthereumProvider extends EventEmitter {
-  constructor() {
-    // Call super for `this` to be defined
-    super();
-
-    // Init storage
-    this._nextJsonRpcId = 0;
-    this._promises = {};
-
-    // Fire the connect
-    this._connect();
-
-    // Listen for jsonrpc responses
-    window.addEventListener('message', this._handleJsonRpcMessage.bind(this));
-  }
-
-  /* Methods */
-
-  send(method, params = []) {
-    if (!method || typeof method !== 'string') {
-      return new Error('Method is not a valid string.');
-    }
-
-    if (!(params instanceof Array)) {
-      return new Error('Params is not a valid array.');
-    }
-
-    const id = this._nextJsonRpcId++;
-    const jsonrpc = '2.0';
-    const payload = { jsonrpc, id, method, params };
-
-    const promise = new Promise((resolve, reject) => {
-      this._promises[payload.id] = { resolve, reject };
-    });
-
-    // Send jsonrpc request to Mist
-    window.postMessage(
-      { type: 'mistAPI_ethereum_provider_write', message: payload },
-      targetOrigin
-    );
-
-    return promise;
-  }
-
-  /* Internal methods */
-
-  _handleJsonRpcMessage(event) {
-    // Return if no data to parse
-    if (!event || !event.data) {
-      return;
-    }
-
-    let data;
-    try {
-      data = JSON.parse(event.data);
-    } catch (error) {
-      // Return if we can't parse a valid object
-      return;
-    }
-
-    // Return if not a jsonrpc response
-    if (!data || !data.message || !data.message.jsonrpc) {
-      return;
-    }
-
-    const message = data.message;
-    const { id, method, error, result } = message;
-
-    if (typeof id !== 'undefined') {
-      const promise = this._promises[id];
-      if (promise) {
-        // Handle pending promise
-        if (data.type === 'error') {
-          promise.reject(message);
-        } else if (message.error) {
-          promise.reject(error);
-        } else {
-          promise.resolve(result);
-        }
-        delete this._promises[id];
-      }
-    } else {
-      if (method && method.indexOf('_subscription') > -1) {
-        // Emit subscription notification
-        this._emitNotification(message.params);
-      }
-    }
-  }
-
-  /* Connection handling */
-
-  _connect() {
-    // Send to Mist
-    window.postMessage(
-      { type: 'mistAPI_ethereum_provider_connect' },
-      targetOrigin
-    );
-
-    // Reconnect on close
-    this.once('close', this._connect.bind(this));
-  }
-
-  /* Events */
-
-  _emitNotification(result) {
-    this.emit('notification', result);
-  }
-
-  _emitConnect() {
-    this.emit('connect');
-  }
-
-  _emitClose(code, reason) {
-    this.emit('close', code, reason);
-  }
-
-  _emitChainChanged(chainId) {
-    this.emit('chainChanged', chainId);
-  }
-
-  _emitAccountsChanged(accounts) {
-    this.emit('accountsChanged', accounts);
-  }
-
-  /*
-     Provide `sendAsync` to be compatible as an older web3.js provider.
-  */
-
-  sendAsync(payload, callback) {
-    return this.send(payload.method, payload.params)
-      .then(result => {
-        const response = payload;
-        response.result = result;
-        callback(null, response);
-      })
-      .catch(error => {
-        callback(error, null);
-        // eslint-disable-next-line no-console
-        console.error(
-          `Error from EthereumProvider sendAsync ${payload}: ${error}`
-        );
-      });
-  }
-}
-```
-
 ## References
 
-* [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
-* [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
+- [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
+- [Initial Ethereum Magicians thread introducing the EIP](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
+- [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
 
 ## Copyright
 


### PR DESCRIPTION
This PR targets some small improvements for EIP 1193:

1. Allows `params` to also be type `Object` to support by-name variables (supported in both JSON-RPC and GraphQL specs).
1. Adds language to encourage support of multiple transport methods beyond JSON-RPC.
1. Improves introduction.
1. Removes own error table in favor of [error codes listed in EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
1. Removes sample class implementation.
   1. I'm not sure if it's useful to include, it was just my reference implementation while working on Mist.
1. Some sentence and grammar improvements to improve clarity.

I posted this PR on my own fork because otherwise the the EIPs GitHub repo would auto-merge it before we could have any discussion.

---

The EIP has a few remaining discussion items before I would like to propose to move to "Last Call":

1. Renaming `send` to `request`
   1. See https://github.com/ethereum/EIPs/issues/2319#issuecomment-590971181
1. Provider capability introspection
   1. See https://github.com/ethereum/EIPs/issues/2319#issuecomment-600602580